### PR TITLE
photoHopper macOS support

### DIFF
--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Generate application package
+pyinstaller --windowed --onefile main.py systemTheme.py utils.py -n photoHopper
+
+# Create installer
+create-dmg --volname "photoHopper" --window-pos 200 120 --window-size 600 300 --icon-size 100 --icon "photoHopper.app" 175 120 --app-drop-link 425 120 --hide-extension "photoHopper.app" "photoHopper.dmg" "dmg/"

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -3,5 +3,9 @@
 # Generate application package
 pyinstaller --windowed --onefile main.py systemTheme.py utils.py -n photoHopper
 
+mkdir -p ./dist/dmg
+
+cp dist/photoHopper.app ./dist/dmg
+
 # Create installer
-create-dmg --volname "photoHopper" --window-pos 200 120 --window-size 600 300 --icon-size 100 --icon "photoHopper.app" 175 120 --app-drop-link 425 120 --hide-extension "photoHopper.app" "photoHopper.dmg" "dmg/"
+create-dmg --volname "photoHopper" --window-pos 200 120 --window-size 600 300 --icon-size 100 --icon "photoHopper.app" 175 120 --app-drop-link 425 120 --hide-extension "photoHopper.app" "photoHopper.dmg" "dist/dmg/"

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import shutil
 import rawpy
 
 from systemTheme import getSysTheme
+import utils
 
 from PyQt6.QtCore import Qt, QModelIndex, QThread, pyqtSignal
 from PyQt6.QtGui import QStandardItemModel, QStandardItem, QPixmap, QFont, QBrush, QColor, QImage
@@ -261,7 +262,8 @@ class MainWindow(QWidget):
         self.searchWorker = None  # QThread 인스턴스를 저장할 변수
 
         # 로그 설정
-        logging.basicConfig(filename='app.log', level=logging.DEBUG,
+        log_filename = os.path.join(utils.get_app_directory(), 'app.log')
+        logging.basicConfig(filename=log_filename, level=logging.DEBUG,
                             format='%(asctime)s %(levelname)s: %(message)s')
     def initUI(self):
         self.setWindowTitle('photoHopper')

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import time
 import re
 import subprocess
 import sys
@@ -177,6 +178,8 @@ class SearchWorker(QThread):
                     LensModel = tag.get('EXIF:LensModel', 'NA')
 
                     if (exifDate == 'NA') and (fileDate == 'NA'):
+                        file_localtime = time.localtime(os.path.getmtime(fileDir))
+                        exifDate = datetime.datetime(*file_localtime[:6])
                         for t in tag.keys():
                             print(f"Key: {t}, value {tag[t]}")
                     else:

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,8 @@
+import sys
+import os
+def get_app_directory():
+    if getattr(sys, 'frozen', False):  # Check if the app is frozen by PyInstaller
+        app_dir = os.path.dirname(sys.executable)
+    else:
+        app_dir = os.path.dirname(os.path.abspath(__file__))
+    return app_dir


### PR DESCRIPTION
- exif에서 파일 생성 날짜를 로드할 수 없을 때 python 기본 함수(os.path.getmtime) 사용하도록 개선
  * macOS에서 발생하는 것을 확인하여 개선하였습니다.
- app.log 경로 로드 부분 개선
  * macOS에서 패키징된 앱을 사용할 경우 기존 상대 경로로는 제약이 있어 수정하였습니다.
- macOS용 빌드 및 dmg 스크립트 작성 기능 추가